### PR TITLE
Phase 4 sqlite persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Current implementation status as of March 25, 2026:
 - Phase 0 is complete: the repo runs locally with a documented setup flow
 - Phase 1 is complete: the scraper has been refactored into a proper Python package
 - Phase 2 is complete: deterministic tests now cover transform, load, and CLI behavior
+- Phase 4 is complete: SQLite persistence now uses a historical `ktc_rankings` schema
 - A full live scrape now succeeds through the new CLI and writes to SQLite
 - `pytest` is now part of the local workflow and enforced in GitHub Actions
 - GitHub Actions CI is active and passing on the repository
@@ -36,7 +37,7 @@ Most recent verified live run:
 Most recent verified test run:
 
 - Command: `./.venv/bin/python -m pytest --cov --cov-report=term-missing --cov-fail-under=90`
-- Result: `28` tests passed with `94%` coverage across the CI-scoped package modules
+- Result: local validation command remains aligned with CI, and Phase 4 tests pass locally
 
 ## Architecture
 
@@ -101,24 +102,26 @@ Backwards-compatible legacy entrypoint:
 The scraper writes to:
 
 - SQLite database: `db/ktc.db`
-- Table: `players`
+- Table: `ktc_rankings`
 
 ## Data Model
 
 The current record shape includes:
 
-- `rank`
+- `scrape_date`
 - `player_name`
 - `position`
-- `position_rank`
+- `rank_overall`
+- `rank_position`
 - `team`
+- `source`
 - `age`
 - `tier`
 - `value`
 - `scraped_at`
 
-The current schema is intentionally simple. Historical deduplication, uniqueness rules, and upsert behavior are planned for the next persistence phase.
-The current SQLite layer now includes duplicate prevention and upsert behavior for the same `player_name` and `scraped_at` pair, while broader persistence design is still planned for a later phase.
+The SQLite persistence layer now stores historical ranking snapshots in `ktc_rankings`.
+The uniqueness rule is based on `scrape_date`, `player_name`, and `source`, which allows historical rows to accumulate across days while preventing duplicates within the same scrape-date snapshot.
 
 ## Quality Strategy
 
@@ -132,6 +135,7 @@ Current quality-oriented implementation choices:
 - the scraper now fails loudly with useful diagnostics instead of silently reporting empty results
 - shared models make the boundaries between layers explicit
 - database behavior is covered with schema, insert, duplicate-prevention, and upsert tests
+- historical snapshot behavior is covered in SQLite tests
 - CI now enforces lint, format, and minimum coverage gates on every change
 
 Current local test coverage includes:
@@ -209,8 +213,15 @@ Current workflow file:
 
 - `db/ktc.db` is local runtime state and should not be committed
 - representative fixture/sample data belongs in the repo, such as [players_sample.json](/home/vhinson/dev/KTC-Webscraping/data/samples/players_sample.json)
-- repeated scrape runs currently append rows
-- duplicate prevention and upsert behavior now exist for the current SQLite workflow
+- repeated scrape runs on different dates accumulate historical rows in `ktc_rankings`
+- duplicate prevention and upsert behavior apply within the same `scrape_date` and `source`
+
+Inspect the local database:
+
+```bash
+sqlite3 db/ktc.db ".tables"
+sqlite3 db/ktc.db "SELECT scrape_date, player_name, rank_overall, rank_position, team FROM ktc_rankings ORDER BY scrape_date DESC, rank_overall ASC LIMIT 20;"
+```
 
 ## Roadmap
 
@@ -218,9 +229,9 @@ The implementation roadmap lives in [todo.md](/home/vhinson/dev/KTC-Webscraping/
 
 Immediate next phases:
 
-- Phase 4: stronger persistence design
 - Phase 5: scheduled automation
 - Phase 6: hosted database readiness
+- Phase 7: CLI and developer experience polish
 
 ## Resume-Style Talking Points
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The scraper writes to:
 
 - SQLite database: `db/ktc.db`
 - Table: `ktc_rankings`
+- Legacy `players` table: retired
 
 ## Data Model
 
@@ -215,6 +216,7 @@ Current workflow file:
 - representative fixture/sample data belongs in the repo, such as [players_sample.json](/home/vhinson/dev/KTC-Webscraping/data/samples/players_sample.json)
 - repeated scrape runs on different dates accumulate historical rows in `ktc_rankings`
 - duplicate prevention and upsert behavior apply within the same `scrape_date` and `source`
+- legacy `players` tables are automatically retired when the current load layer initializes the database
 
 Inspect the local database:
 

--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ def read_rankings(
     cursor = conn.cursor()
 
     # Build dynamic WHERE clause
-    query = "SELECT * FROM players"
+    query = "SELECT * FROM ktc_rankings"
     filters = []
     values = []
 
@@ -43,7 +43,7 @@ def read_rankings(
     if filters:
         query += " WHERE " + " AND ".join(filters)
 
-    query += " ORDER BY rank ASC"
+    query += " ORDER BY scrape_date DESC, rank_overall ASC"
 
     # Pagination logic
     offset = (page - 1) * limit
@@ -62,7 +62,7 @@ def read_rankings(
 def get_player_by_id(player_id: int):
     conn = get_db_connection()
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM players WHERE id = ?", (player_id,))
+    cursor.execute("SELECT * FROM ktc_rankings WHERE id = ?", (player_id,))
     row = cursor.fetchone()
     conn.close()
 
@@ -76,7 +76,15 @@ def get_player_by_id(player_id: int):
 def get_player_by_name(name: str = Query(...)):
     conn = get_db_connection()
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM players WHERE LOWER(player_name) LIKE LOWER(?)", (f"%{name}%",))
+    cursor.execute(
+        """
+        SELECT *
+        FROM ktc_rankings
+        WHERE LOWER(player_name) LIKE LOWER(?)
+        ORDER BY scrape_date DESC, rank_overall ASC
+        """,
+        (f"%{name}%",),
+    )
     rows = cursor.fetchall()
     conn.close()
 

--- a/ktc_webscraping/load.py
+++ b/ktc_webscraping/load.py
@@ -6,11 +6,13 @@ from .models import PlayerRecord
 
 def player_to_row(player: PlayerRecord) -> tuple:
     return (
-        player.rank,
+        player.scrape_date,
         player.player_name,
         player.position,
-        player.position_rank,
+        player.rank_overall,
+        player.rank_position,
         player.team,
+        player.source,
         player.age,
         player.tier,
         player.value,
@@ -26,13 +28,15 @@ def create_connection(db_file: Path | str) -> sqlite3.Connection:
     cursor = conn.cursor()
     cursor.execute(
         """
-        CREATE TABLE IF NOT EXISTS players (
+        CREATE TABLE IF NOT EXISTS ktc_rankings (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            rank INTEGER,
+            scrape_date TEXT NOT NULL,
             player_name TEXT,
             position TEXT,
-            position_rank INTEGER,
+            rank_overall INTEGER,
+            rank_position INTEGER,
             team TEXT,
+            source TEXT NOT NULL,
             age REAL,
             tier INTEGER,
             value REAL,
@@ -42,8 +46,8 @@ def create_connection(db_file: Path | str) -> sqlite3.Connection:
     )
     cursor.execute(
         """
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_players_player_name_scraped_at
-        ON players (player_name, scraped_at)
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_ktc_rankings_scrape_date_player_source
+        ON ktc_rankings (scrape_date, player_name, source)
         """
     )
     conn.commit()
@@ -54,13 +58,25 @@ def insert_player_data(conn: sqlite3.Connection, players: list[PlayerRecord]) ->
     cursor = conn.cursor()
     cursor.executemany(
         """
-        INSERT INTO players
-        (rank, player_name, position, position_rank, team, age, tier, value, scraped_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(player_name, scraped_at) DO UPDATE SET
-            rank = excluded.rank,
+        INSERT INTO ktc_rankings
+        (
+            scrape_date,
+            player_name,
+            position,
+            rank_overall,
+            rank_position,
+            team,
+            source,
+            age,
+            tier,
+            value,
+            scraped_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(scrape_date, player_name, source) DO UPDATE SET
             position = excluded.position,
-            position_rank = excluded.position_rank,
+            rank_overall = excluded.rank_overall,
+            rank_position = excluded.rank_position,
             team = excluded.team,
             age = excluded.age,
             tier = excluded.tier,

--- a/ktc_webscraping/load.py
+++ b/ktc_webscraping/load.py
@@ -50,6 +50,8 @@ def create_connection(db_file: Path | str) -> sqlite3.Connection:
         ON ktc_rankings (scrape_date, player_name, source)
         """
     )
+    cursor.execute("DROP TABLE IF EXISTS players")
+    cursor.execute("DROP INDEX IF EXISTS idx_players_player_name_scraped_at")
     conn.commit()
     return conn
 

--- a/ktc_webscraping/models.py
+++ b/ktc_webscraping/models.py
@@ -4,11 +4,13 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class PlayerRecord:
-    rank: int | None
+    scrape_date: str
     player_name: str
     position: str
-    position_rank: int | None
+    rank_overall: int | None
+    rank_position: int | None
     team: str | None
+    source: str
     age: float | None
     tier: int | None
     value: float | None

--- a/ktc_webscraping/transform.py
+++ b/ktc_webscraping/transform.py
@@ -57,11 +57,13 @@ def parse_player_row(row, scrape_timestamp: str) -> PlayerRecord | None:
             age = safe_float(age_text.replace(" y.o.", ""))
 
     return PlayerRecord(
-        rank=safe_int(rank_node.get_text(strip=True)),
+        scrape_date=scrape_timestamp.split("T", maxsplit=1)[0],
         player_name=name_node.get_text(strip=True),
         position=position,
-        position_rank=position_rank,
+        rank_overall=safe_int(rank_node.get_text(strip=True)),
+        rank_position=position_rank,
         team=team,
+        source="keeptradecut",
         age=age,
         tier=safe_int(tier_node.get_text(strip=True).replace("Tier ", "")),
         value=safe_float(value_node.get_text(strip=True)),
@@ -99,11 +101,13 @@ def parse_player_text_lines(lines: list[str], scrape_timestamp: str) -> PlayerRe
 
     if position_text == "PICK":
         return PlayerRecord(
-            rank=rank,
+            scrape_date=scrape_timestamp.split("T", maxsplit=1)[0],
             player_name=player_name,
             position="PICK",
-            position_rank=None,
+            rank_overall=rank,
+            rank_position=None,
             team=team,
+            source="keeptradecut",
             age=None,
             tier=tier,
             value=value,
@@ -117,11 +121,13 @@ def parse_player_text_lines(lines: list[str], scrape_timestamp: str) -> PlayerRe
 
     position, position_rank = normalize_position(position_text)
     return PlayerRecord(
-        rank=rank,
+        scrape_date=scrape_timestamp.split("T", maxsplit=1)[0],
         player_name=player_name,
         position=position,
-        position_rank=position_rank,
+        rank_overall=rank,
+        rank_position=position_rank,
         team=team,
+        source="keeptradecut",
         age=age,
         tier=tier,
         value=value,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,11 +66,13 @@ def text_layout_html() -> str:
 @pytest.fixture
 def sample_player(scrape_timestamp: str) -> PlayerRecord:
     return PlayerRecord(
-        rank=1,
+        scrape_date="2026-03-21",
         player_name="Josh Allen",
         position="QB",
-        position_rank=1,
+        rank_overall=1,
+        rank_position=1,
         team="BUF",
+        source="keeptradecut",
         age=29.8,
         tier=1,
         value=9989.0,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,11 +50,13 @@ def test_run_uses_load_and_extract_layers(monkeypatch, tmp_path: Path, capsys) -
     )
     players = [
         PlayerRecord(
-            rank=1,
+            scrape_date="2026-03-21",
             player_name="Josh Allen",
             position="QB",
-            position_rank=1,
+            rank_overall=1,
+            rank_position=1,
             team="BUF",
+            source="keeptradecut",
             age=29.8,
             tier=1,
             value=9989.0,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -52,6 +52,36 @@ def test_create_connection_creates_unique_index_for_scrape_date_player_and_sourc
     )
 
 
+def test_create_connection_retires_legacy_players_table(temp_db_path) -> None:
+    conn = sqlite3.connect(temp_db_path)
+    conn.execute("CREATE TABLE players (id INTEGER PRIMARY KEY, player_name TEXT)")
+    conn.execute(
+        "CREATE UNIQUE INDEX idx_players_player_name_scraped_at ON players (player_name, id)"
+    )
+    conn.commit()
+    conn.close()
+
+    conn = create_connection(temp_db_path)
+    legacy_table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'players'"
+    ).fetchone()
+    legacy_index = conn.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'index' AND name = 'idx_players_player_name_scraped_at'
+        """
+    ).fetchone()
+    rankings_table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'ktc_rankings'"
+    ).fetchone()
+    conn.close()
+
+    assert legacy_table is None
+    assert legacy_index is None
+    assert rankings_table == ("ktc_rankings",)
+
+
 def test_insert_player_data_persists_player_records(
     temp_db_path, sample_player: PlayerRecord
 ) -> None:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -4,48 +4,51 @@ from ktc_webscraping.load import create_connection, insert_player_data
 from ktc_webscraping.models import PlayerRecord
 
 
-def test_create_connection_creates_database_and_players_table(temp_db_path) -> None:
+def test_create_connection_creates_database_and_rankings_table(temp_db_path) -> None:
     conn = create_connection(temp_db_path)
 
     table_name = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'players'"
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'ktc_rankings'"
     ).fetchone()
     conn.close()
 
     assert temp_db_path.exists()
-    assert table_name == ("players",)
+    assert table_name == ("ktc_rankings",)
 
 
-def test_create_connection_creates_expected_players_schema(temp_db_path) -> None:
+def test_create_connection_creates_expected_rankings_schema(temp_db_path) -> None:
     conn = create_connection(temp_db_path)
 
-    columns = conn.execute("PRAGMA table_info(players)").fetchall()
+    columns = conn.execute("PRAGMA table_info(ktc_rankings)").fetchall()
     conn.close()
 
     assert columns == [
         (0, "id", "INTEGER", 0, None, 1),
-        (1, "rank", "INTEGER", 0, None, 0),
+        (1, "scrape_date", "TEXT", 1, None, 0),
         (2, "player_name", "TEXT", 0, None, 0),
         (3, "position", "TEXT", 0, None, 0),
-        (4, "position_rank", "INTEGER", 0, None, 0),
-        (5, "team", "TEXT", 0, None, 0),
-        (6, "age", "REAL", 0, None, 0),
-        (7, "tier", "INTEGER", 0, None, 0),
-        (8, "value", "REAL", 0, None, 0),
-        (9, "scraped_at", "TEXT", 0, None, 0),
+        (4, "rank_overall", "INTEGER", 0, None, 0),
+        (5, "rank_position", "INTEGER", 0, None, 0),
+        (6, "team", "TEXT", 0, None, 0),
+        (7, "source", "TEXT", 1, None, 0),
+        (8, "age", "REAL", 0, None, 0),
+        (9, "tier", "INTEGER", 0, None, 0),
+        (10, "value", "REAL", 0, None, 0),
+        (11, "scraped_at", "TEXT", 0, None, 0),
     ]
 
 
-def test_create_connection_creates_unique_index_for_player_and_scrape_timestamp(
+def test_create_connection_creates_unique_index_for_scrape_date_player_and_source(
     temp_db_path,
 ) -> None:
     conn = create_connection(temp_db_path)
 
-    indexes = conn.execute("PRAGMA index_list(players)").fetchall()
+    indexes = conn.execute("PRAGMA index_list(ktc_rankings)").fetchall()
     conn.close()
 
     assert any(
-        index[1] == "idx_players_player_name_scraped_at" and index[2] == 1 for index in indexes
+        index[1] == "idx_ktc_rankings_scrape_date_player_source" and index[2] == 1
+        for index in indexes
     )
 
 
@@ -57,18 +60,31 @@ def test_insert_player_data_persists_player_records(
     insert_player_data(conn, [sample_player])
     row = conn.execute(
         """
-        SELECT rank, player_name, position, position_rank, team, age, tier, value, scraped_at
-        FROM players
+        SELECT
+            scrape_date,
+            player_name,
+            position,
+            rank_overall,
+            rank_position,
+            team,
+            source,
+            age,
+            tier,
+            value,
+            scraped_at
+        FROM ktc_rankings
         """
     ).fetchone()
     conn.close()
 
     assert row == (
-        1,
+        "2026-03-21",
         "Josh Allen",
         "QB",
         1,
+        1,
         "BUF",
+        "keeptradecut",
         29.8,
         1,
         9989.0,
@@ -80,7 +96,7 @@ def test_insert_player_data_accepts_empty_input(temp_db_path) -> None:
     conn = create_connection(temp_db_path)
 
     insert_player_data(conn, [])
-    count = conn.execute("SELECT COUNT(*) FROM players").fetchone()[0]
+    count = conn.execute("SELECT COUNT(*) FROM ktc_rankings").fetchone()[0]
     conn.close()
 
     assert count == 0
@@ -91,27 +107,66 @@ def test_load_layer_persists_multiple_rows_and_scrape_dates(
 ) -> None:
     conn = create_connection(temp_db_path)
     players = [
-        PlayerRecord(1, "Josh Allen", "QB", 1, "BUF", 29.8, 1, 9989.0, scrape_timestamp),
-        PlayerRecord(2, "Bijan Robinson", "RB", 1, "ATL", 24.1, 1, 9999.0, "2026-03-22T00:00:00"),
+        PlayerRecord(
+            "2026-03-21",
+            "Josh Allen",
+            "QB",
+            1,
+            1,
+            "BUF",
+            "keeptradecut",
+            29.8,
+            1,
+            9989.0,
+            scrape_timestamp,
+        ),
+        PlayerRecord(
+            "2026-03-22",
+            "Bijan Robinson",
+            "RB",
+            2,
+            1,
+            "ATL",
+            "keeptradecut",
+            24.1,
+            1,
+            9999.0,
+            "2026-03-22T00:00:00",
+        ),
     ]
 
     insert_player_data(conn, players)
-    rows = conn.execute("SELECT player_name, scraped_at FROM players ORDER BY rank").fetchall()
+    rows = conn.execute(
+        "SELECT player_name, scrape_date FROM ktc_rankings ORDER BY rank_overall"
+    ).fetchall()
     conn.close()
 
     assert rows == [
-        ("Josh Allen", scrape_timestamp),
-        ("Bijan Robinson", "2026-03-22T00:00:00"),
+        ("Josh Allen", "2026-03-21"),
+        ("Bijan Robinson", "2026-03-22"),
     ]
 
 
 def test_load_layer_preserves_float_fields(temp_db_path, scrape_timestamp: str) -> None:
     conn = create_connection(temp_db_path)
-    player = PlayerRecord(3, "Test Player", "WR", 8, "SEA", 24.3, 2, 7777.5, scrape_timestamp)
+    player = PlayerRecord(
+        "2026-03-21",
+        "Test Player",
+        "WR",
+        3,
+        8,
+        "SEA",
+        "keeptradecut",
+        24.3,
+        2,
+        7777.5,
+        scrape_timestamp,
+    )
 
     insert_player_data(conn, [player])
     age, value = conn.execute(
-        "SELECT age, value FROM players WHERE player_name = ?", ("Test Player",)
+        "SELECT age, value FROM ktc_rankings WHERE player_name = ?",
+        ("Test Player",),
     ).fetchone()
     conn.close()
 
@@ -121,36 +176,108 @@ def test_load_layer_preserves_float_fields(temp_db_path, scrape_timestamp: str) 
     assert value == 7777.5
 
 
-def test_load_layer_prevents_duplicate_player_and_scrape_timestamp(
+def test_load_layer_prevents_duplicate_player_and_scrape_date(
     temp_db_path, sample_player: PlayerRecord
 ) -> None:
     conn = create_connection(temp_db_path)
 
     insert_player_data(conn, [sample_player, sample_player])
-    count = conn.execute("SELECT COUNT(*) FROM players").fetchone()[0]
+    count = conn.execute("SELECT COUNT(*) FROM ktc_rankings").fetchone()[0]
     conn.close()
 
     assert count == 1
 
 
-def test_load_layer_upserts_existing_player_for_same_scrape_timestamp(
+def test_load_layer_upserts_existing_player_for_same_scrape_date(
     temp_db_path, scrape_timestamp: str
 ) -> None:
     conn = create_connection(temp_db_path)
-    original = PlayerRecord(1, "Josh Allen", "QB", 1, "BUF", 29.8, 1, 9989.0, scrape_timestamp)
-    updated = PlayerRecord(2, "Josh Allen", "QB", 1, "BUF", 29.9, 1, 9995.0, scrape_timestamp)
+    original = PlayerRecord(
+        "2026-03-21",
+        "Josh Allen",
+        "QB",
+        1,
+        1,
+        "BUF",
+        "keeptradecut",
+        29.8,
+        1,
+        9989.0,
+        scrape_timestamp,
+    )
+    updated = PlayerRecord(
+        "2026-03-21",
+        "Josh Allen",
+        "QB",
+        2,
+        1,
+        "BUF",
+        "keeptradecut",
+        29.9,
+        1,
+        9995.0,
+        scrape_timestamp,
+    )
 
     insert_player_data(conn, [original])
     insert_player_data(conn, [updated])
     row = conn.execute(
-        "SELECT rank, age, value FROM players WHERE player_name = ? AND scraped_at = ?",
-        ("Josh Allen", scrape_timestamp),
+        """
+        SELECT rank_overall, age, value
+        FROM ktc_rankings
+        WHERE scrape_date = ? AND player_name = ? AND source = ?
+        """,
+        ("2026-03-21", "Josh Allen", "keeptradecut"),
     ).fetchone()
-    count = conn.execute("SELECT COUNT(*) FROM players").fetchone()[0]
+    count = conn.execute("SELECT COUNT(*) FROM ktc_rankings").fetchone()[0]
     conn.close()
 
     assert count == 1
     assert row == (2, 29.9, 9995.0)
+
+
+def test_load_layer_accumulates_historical_rows_across_scrape_dates(temp_db_path) -> None:
+    conn = create_connection(temp_db_path)
+    first = PlayerRecord(
+        "2026-03-21",
+        "Josh Allen",
+        "QB",
+        1,
+        1,
+        "BUF",
+        "keeptradecut",
+        29.8,
+        1,
+        9989.0,
+        "2026-03-21T00:00:00",
+    )
+    second = PlayerRecord(
+        "2026-03-22",
+        "Josh Allen",
+        "QB",
+        2,
+        1,
+        "BUF",
+        "keeptradecut",
+        29.8,
+        1,
+        9975.0,
+        "2026-03-22T00:00:00",
+    )
+
+    insert_player_data(conn, [first, second])
+    rows = conn.execute(
+        """
+        SELECT scrape_date, rank_overall
+        FROM ktc_rankings
+        WHERE player_name = ?
+        ORDER BY scrape_date
+        """,
+        ("Josh Allen",),
+    ).fetchall()
+    conn.close()
+
+    assert rows == [("2026-03-21", 1), ("2026-03-22", 2)]
 
 
 def test_load_layer_returns_sqlite_connection(temp_db_path) -> None:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -39,11 +39,13 @@ def test_parse_player_row_from_legacy_html(legacy_row_html: str, scrape_timestam
     record = parse_player_row(row, scrape_timestamp)
 
     assert record == PlayerRecord(
-        rank=1,
+        scrape_date="2026-03-21",
         player_name="Josh Allen",
         position="QB",
-        position_rank=1,
+        rank_overall=1,
+        rank_position=1,
         team="BUF",
+        source="keeptradecut",
         age=29.8,
         tier=1,
         value=9989.0,
@@ -66,11 +68,13 @@ def test_parse_player_text_lines_handles_standard_player(scrape_timestamp: str) 
     record = parse_player_text_lines(lines, scrape_timestamp)
 
     assert record == PlayerRecord(
-        rank=1,
+        scrape_date="2026-03-21",
         player_name="Bijan Robinson",
         position="RB",
-        position_rank=1,
+        rank_overall=1,
+        rank_position=1,
         team="ATL",
+        source="keeptradecut",
         age=24.1,
         tier=1,
         value=9999.0,
@@ -84,11 +88,13 @@ def test_parse_player_text_lines_handles_pick_rows(scrape_timestamp: str) -> Non
     record = parse_player_text_lines(lines, scrape_timestamp)
 
     assert record == PlayerRecord(
-        rank=2,
+        scrape_date="2026-03-21",
         player_name="2027 Early 1st",
         position="PICK",
-        position_rank=None,
+        rank_overall=2,
+        rank_position=None,
         team="FA",
+        source="keeptradecut",
         age=None,
         tier=5,
         value=6810.0,
@@ -114,7 +120,7 @@ def test_parse_player_text_lines_normalizes_whitespace(scrape_timestamp: str) ->
     assert record.player_name == "Ja'Marr Chase"
     assert record.team == "CIN"
     assert record.position == "WR"
-    assert record.position_rank == 1
+    assert record.rank_position == 1
 
 
 def test_parse_player_text_lines_returns_none_for_missing_tier(scrape_timestamp: str) -> None:
@@ -143,7 +149,7 @@ def test_extract_rankings_text_lines_and_parse_current_layout(
     assert records[0].player_name == "Bijan Robinson"
     assert records[0].team == "ATL"
     assert records[1].position == "PICK"
-    assert records[1].position_rank is None
+    assert records[1].rank_position is None
     assert records[1].team == "FA"
 
 

--- a/todo.md
+++ b/todo.md
@@ -13,13 +13,15 @@ Turn this repo into a credible proof project for remote QA / SDET / Quality Engi
 - Phase 1 is complete
 - Phase 2 is complete
 - Phase 3 is complete
+- Phase 4 is complete
 - Live Phase 1 scrape is verified through `./.venv/bin/python -m ktc_webscraping.cli --page-count 10`
 - Most recent verified full run inserted `500` records into `db/ktc.db`
 - `pytest` coverage is in place for transform, load, and CLI behavior
 - GitHub Actions CI is active and green
 - Ruff and coverage checks are part of the CI workflow
 - Current local CI-equivalent validation passes with 28 tests and 94% coverage
-- Phase 4 is the next implementation focus
+- Historical SQLite persistence is now modeled through `ktc_rankings`
+- Phase 5 is the next implementation focus
 
 ---
 
@@ -160,21 +162,21 @@ Purpose: turn the current refactor plus deterministic tests into visible, recrui
 
 ## Phase 4 - Add Local Database Persistence
 
-- [ ] Create initial SQLite database integration
-- [ ] Define `ktc_rankings` schema with fields such as:
-  - [ ] `scrape_date`
-  - [ ] `player_name`
-  - [ ] `position`
-  - [ ] `rank_overall`
-  - [ ] `rank_position`
-  - [ ] `team`
-  - [ ] `source`
-- [ ] Decide on primary key or uniqueness logic
-- [ ] Implement insert / upsert strategy
-- [ ] Prevent duplicate records for the same scrape date and player
-- [ ] Verify historical rows can accumulate over time
-- [ ] Add configuration for local DB path
-- [ ] Document how to inspect the SQLite database locally
+- [X] Create initial SQLite database integration
+- [X] Define `ktc_rankings` schema with fields such as:
+  - [X] `scrape_date`
+  - [X] `player_name`
+  - [X] `position`
+  - [X] `rank_overall`
+  - [X] `rank_position`
+  - [X] `team`
+  - [X] `source`
+- [X] Decide on primary key or uniqueness logic
+- [X] Implement insert / upsert strategy
+- [X] Prevent duplicate records for the same scrape date and player
+- [X] Verify historical rows can accumulate over time
+- [X] Add configuration for local DB path
+- [X] Document how to inspect the SQLite database locally
 
 **Definition of done**
 - Data is stored in a structured database


### PR DESCRIPTION
This PR completes Phase 4 by upgrading the project’s local persistence layer from the old `players` table to a historical `ktc_rankings` schema that better reflects an ETL-style data model. The new schema stores `scrape_date`, `player_name`, `position`, `rank_overall`, `rank_position`, `team`, `source`, `age`, `tier`, `value`, and `scraped_at`, with a uniqueness rule on `scrape_date`, `player_name`, and `source` so same-day duplicates are prevented while historical rows can accumulate across dates.

The load layer, shared record model, transform output, and FastAPI queries were updated to use the new schema, and the legacy `players` table is now retired automatically when the current database layer initializes. The test suite was expanded to cover the new schema, upsert behavior, duplicate prevention, and historical accumulation, and the README/todo documentation now reflects the completed Phase 4 persistence design and local database inspection flow.